### PR TITLE
Fix typo in Program.cs: `entpoint` to `endpoint`

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -39,7 +39,7 @@ builder.Services.AddSwaggerGen(options =>
     {
         Version = "v1",
         Title = "Woodgrove demo API",
-        Description = "This dotnet Web API entpoint demonstrate how to use Microsoft Entra External ID's custom authentication extension for various events. Checkout the [source code](https://github.com/microsoft/woodgrove-api) and [request samples](./help.html) <br> <br> Assembly version " + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(),
+        Description = "This dotnet Web API endpoint demonstrate how to use Microsoft Entra External ID's custom authentication extension for various events. Checkout the [source code](https://github.com/microsoft/woodgrove-api) and [request samples](./help.html) <br> <br> Assembly version " + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(),
     });
 });
 


### PR DESCRIPTION
Minor Typo Fix!